### PR TITLE
feat: relative time function

### DIFF
--- a/src/getRelativeTime.ts
+++ b/src/getRelativeTime.ts
@@ -1,0 +1,19 @@
+export const  getRelativeTime = (date: Date | string | number) => {
+  if(!date) return '';
+
+  const now = Date.now();
+  const inputTime = new Date(date).getTime();
+  const diffMs = now - inputTime;
+
+  const seconds = Math.floor(diffMs / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (seconds < 60) return "just now";
+  if (minutes < 60) return `${minutes} minute${minutes !== 1 ? 's' : ''} ago`;
+  if (hours < 24) return `${hours} hour${hours !== 1 ? 's' : ''} ago`;
+  if (days < 7) return `${days} day${days !== 1 ? 's' : ''} ago`;
+
+  return new Date(date).toLocaleDateString();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-// TODO: Implement library code
+export * from "@/getRelativeTime";


### PR DESCRIPTION
# Displaying relative time 

Nobody wants to read timestamps that look like they came out of The Matrix.

Your users don’t think in ISO strings; they think in `5 minutes ago`, `yesterday`, or `just now`.


## Do they say:
2025-08-27T14:32:12.000Z?

## They say:
- `2 hours ago`
- `Yesterday`
- `just now`

That tiny shift makes your UI feel alive, fresh, and human-friendly.

## How it works
We build a custom function that:

1. Compare the given date to ```date.now()```
2. Convert the difference into seconds, minutes, hours, and days.
3. Use a few quick if statements to decide which label makes sense.
4. Return human-readable text instead of a scary timestamp.

Example output
- 5 seconds ago → just now
- 180 seconds → 3 minutes ago
- 2 hours → 2 hours ago
- 5 days → 5 days ago

Older than a week? We do return the date 📅 
